### PR TITLE
Pass Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest pytest-pep8
   - source activate test-environment
-  - conda install pytorch torchvision -c pytorch
+  - conda install pytorch==0.4.0 torchvision -c pytorch
   - mkdir build && cd build && cmake .. && make && sudo make install && cd .. && sudo ldconfig
   - cd pytorch_binding && python setup.py install && cd .. && sudo ldconfig
 

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -13,6 +13,7 @@ def _assert_no_grad(tensor):
         "gradients only computed for acts - please " \
         "mark other tensors as not requiring gradients"
 
+
 class _CTC(Function):
     @staticmethod
     def forward(ctx, acts, labels, act_lens, label_lens, size_average=False,
@@ -45,8 +46,9 @@ class _CTC(Function):
                 grads = grads / minibatch_size
                 costs = costs / minibatch_size
         else:
-            costs = costs.unsqueeze(1) # Make the costs size be B x 1, then grad_output is also B x 1
-                                       # Thus the `grad_output' in backward() is broadcastable
+            # Make the costs size be B x 1, then grad_output is also B x 1
+            # Thus the `grad_output' in backward() is broadcastable
+            costs = costs.unsqueeze(1)
 
         ctx.grads = grads
         return costs


### PR DESCRIPTION
This PR will enable `pytorch_bindings` branch to pass Travis build.

- ea97748
  - This commit will make it explicit to install PyTorch 0.4.0. Otherwise, 1.1.0 is installed and build fails.
- 6f24919
  - This commit will let the code pass pep8 check.
  - After this PR is merged, the commit may be cherry-picked to other branches (e.x. `pytorch-1.0.0`).