### PR TITLE
Build wheel for Pytorch 1.0.0 and CUDA 10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,37 +3,32 @@ dist: xenial
 language: python
 services:
   - docker
-python:
-  - "3.6"
-  - "3.7"
 env:
-  - TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
+  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
+  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
 before_install:
   - docker pull $DOCKER_IMAGE_NAME
   - docker run --rm -d --name warpctc_builder_container -v ${PWD}:${PWD} -w ${PWD} $DOCKER_IMAGE_NAME sleep inf
 install:
-  - docker exec -e PYTHON_VERSION=$TRAVIS_PYTHON_VERSION warpctc_builder_container /bin/bash -cl \
-    'conda create -q -n test-environment python=$PYTHON_VERSION pytest pytest-pep8'
-  - docker exec -e TORCH_VERSION=$TORCH_VERSION warpctc_builder_container /bin/bash -cl \
-    'source activate test-environment && conda install pytorch==$TORCH_VERSION torchvision -c pytorch'
-  # Useful for debugging any issues with conda
+  - docker exec -e PYTHON_VERSION=$PYTHON_VERSION warpctc_builder_container /bin/bash -cl \
+    'pyenv global $PYTHON_VERSION'
   - docker exec warpctc_builder_container /bin/bash -cl \
-    'source activate test-environment && conda info -a'
+    'pip install -U pip setuptools && pip install pytest pytest-pep8 wheel'
+  - docker exec -e TORCH_VERSION=$TORCH_VERSION warpctc_builder_container /bin/bash -cl \
+    'pip install torch==$TORCH_VERSION torchvision'
 
   - docker exec warpctc_builder_container /bin/bash -cl \
-    'mkdir build && cd build && cmake .. && make && make install && ldconfig'
+    'mkdir build && cd build && cmake .. && make'
   - docker exec warpctc_builder_container /bin/bash -cl \
-    'source activate test-environment && cd pytorch_binding && python setup.py install && ldconfig'
+    'cd pytorch_binding && python setup.py bdist_wheel && pip install dist/*.whl'
 
 script:
   - docker exec warpctc_builder_container /bin/bash -cl \
-    'source activate test-environment && cd pytorch_binding && py.test tests'
+    'cd pytorch_binding && py.test tests'
   - docker exec warpctc_builder_container /bin/bash -cl \
-    'source activate test-environment && cd pytorch_binding && py.test --pep8 -m pep8 --ignore=warpctc_pytorch/_warp_ctc'
+    'cd pytorch_binding && py.test --pep8 -m pep8 --ignore=warpctc_pytorch/_warp_ctc'
   - docker exec warpctc_builder_container /bin/bash -cl \
-    'source activate test-environment && cd pytorch_binding && python setup.py bdist_wheel'
-  - docker exec warpctc_builder_container /bin/bash -cl \
-    'ls -1 pytorch_binding/dist/*.whl | awk "{print \"mv \"\$1\" \"\$1}" | sed "s/-linux_/-manylinux1_/2" | bash'
+    'cd pytorch_binding && ls -1 dist/*.whl | awk "{print \"mv \"\$1\" \"\$1}" | sed "s/-linux_/-manylinux1_/2" | bash && ls dist/'
 
 after_script:
   - docker stop warpctc_builder_container

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,35 @@
 sudo: required
 dist: xenial
 language: python
+services:
+  - docker
 python:
-  - "2.7"
   - "3.6"
+  - "3.7"
+env:
+  - TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
+before_install:
+  - docker pull $DOCKER_IMAGE_NAME
+  - docker run --rm -d --name warpctc_builder_container -v ${PWD}:${PWD} -w ${PWD} $DOCKER_IMAGE_NAME sleep inf
 install:
-  ## Start conda installation
-  # https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html
-  - sudo apt-get update
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
+  - docker exec -e PYTHON_VERSION=$TRAVIS_PYTHON_VERSION warpctc_builder_container /bin/bash -cl \
+    'conda create -q -n test-environment python=$PYTHON_VERSION pytest pytest-pep8'
+  - docker exec -e TORCH_VERSION=$TORCH_VERSION warpctc_builder_container /bin/bash -cl \
+    'source activate test-environment && conda install pytorch==$TORCH_VERSION torchvision -c pytorch'
   # Useful for debugging any issues with conda
-  - conda info -a
-  ## End conda installation
-  
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest pytest-pep8
-  - source activate test-environment
-  - conda install pytorch torchvision -c pytorch
-  - mkdir build && cd build && cmake .. && make && sudo make install && cd .. && sudo ldconfig
-  - cd pytorch_binding && python setup.py install && cd .. && sudo ldconfig
+  - docker exec warpctc_builder_container /bin/bash -cl \
+    'source activate test-environment && conda info -a'
+
+  - docker exec warpctc_builder_container /bin/bash -cl \
+    'mkdir build && cd build && cmake .. && make && make install && ldconfig'
+  - docker exec warpctc_builder_container /bin/bash -cl \
+    'source activate test-environment && cd pytorch_binding && python setup.py install && ldconfig'
 
 script:
-  - cd pytorch_binding && py.test tests && cd ..
-  - cd pytorch_binding && py.test --pep8 -m pep8 --ignore=warpctc_pytorch/_warp_ctc && cd ..
+  - docker exec warpctc_builder_container /bin/bash -cl \
+    'source activate test-environment && cd pytorch_binding && py.test tests'
+  - docker exec warpctc_builder_container /bin/bash -cl \
+    'source activate test-environment && cd pytorch_binding && py.test --pep8 -m pep8 --ignore=warpctc_pytorch/_warp_ctc'
+
+after_script:
+  - docker stop warpctc_builder_container

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ script:
     'source activate test-environment && cd pytorch_binding && py.test tests'
   - docker exec warpctc_builder_container /bin/bash -cl \
     'source activate test-environment && cd pytorch_binding && py.test --pep8 -m pep8 --ignore=warpctc_pytorch/_warp_ctc'
+  - docker exec warpctc_builder_container /bin/bash -cl \
+    'source activate test-environment && cd pytorch_binding && python setup.py bdist_wheel'
+  - docker exec warpctc_builder_container /bin/bash -cl \
+    'ls -1 pytorch_binding/dist/*.whl | awk "{print \"mv \"\$1\" \"\$1}" | sed "s/-linux_/-manylinux1_/2" | bash'
 
 after_script:
   - docker stop warpctc_builder_container

--- a/ci/cuda101/Dockerfile
+++ b/ci/cuda101/Dockerfile
@@ -1,0 +1,15 @@
+FROM nvidia/cuda:10.1-cudnn7-devel-centos7
+
+ENV CUDA_HOME /usr/local/cuda
+
+RUN yum update -y
+RUN yum install -y centos-release-scl \
+  && yum install -y devtoolset-3-gcc-c++ \
+  && echo 'source scl_source enable devtoolset-3' >> ~/.bash_profile
+RUN yum install -y make cmake which
+# Install miniconda
+ENV PATH /root/miniconda/bin:$PATH
+RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh \
+  && bash miniconda.sh -b -p /root/miniconda \
+  && conda config --set always_yes yes --set changeps1 no \
+  && conda update -q conda

--- a/ci/cuda101/Dockerfile
+++ b/ci/cuda101/Dockerfile
@@ -6,10 +6,14 @@ RUN yum update -y
 RUN yum install -y centos-release-scl \
   && yum install -y devtoolset-3-gcc-c++ \
   && echo 'source scl_source enable devtoolset-3' >> ~/.bash_profile
-RUN yum install -y make cmake which
-# Install miniconda
-ENV PATH /root/miniconda/bin:$PATH
-RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh \
-  && bash miniconda.sh -b -p /root/miniconda \
-  && conda config --set always_yes yes --set changeps1 no \
-  && conda update -q conda
+RUN yum install -y make cmake which git \
+  && yum install -y zlib-devel libffi-devel bzip2-devel openssl-devel readline-devel
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
+ENV PYENV_ROOT /opt/pyenv
+ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
+# Install Python
+ENV PYTHON_VERSIONS 3.6.9 3.7.4
+RUN for python_version in ${PYTHON_VERSIONS}; do \
+      pyenv install ${python_version}; \
+    done

--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -3,6 +3,7 @@ import platform
 import shutil
 import sys
 from setuptools import setup, find_packages
+from subprocess import Popen, PIPE
 
 from torch.utils.cpp_extension import BuildExtension, CppExtension
 import torch
@@ -49,6 +50,21 @@ if enable_gpu:
 else:
     build_extension = CppExtension
 
+
+def get_cuda_version():
+    proc = Popen(['nvcc', '--version'], stdout=PIPE, stderr=PIPE)
+    out, err = proc.communicate()
+    out.decode('utf-8').split('\n')[-2].split(', ')[-2].split(' ')
+    return out.decode('utf-8').split()[-2][:-1].replace('.', '')
+
+
+def get_torch_version():
+    return torch.__version__.replace('.', '')
+
+
+package_name = 'warpctc_pytorch{}_cuda{}'.format(
+    get_torch_version(), get_cuda_version())
+
 ext_modules = [
     build_extension(
         name='warpctc_pytorch._warp_ctc',
@@ -63,7 +79,7 @@ ext_modules = [
 ]
 
 setup(
-    name="warpctc_pytorch",
+    name=package_name,
     version="0.1.1",
     description="PyTorch wrapper for warp-ctc",
     url="https://github.com/baidu-research/warp-ctc",

--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import shutil
 import sys
 from setuptools import setup, find_packages
 
@@ -7,22 +8,32 @@ from torch.utils.cpp_extension import BuildExtension, CppExtension
 import torch
 
 extra_compile_args = ['-std=c++11', '-fPIC']
-warp_ctc_path = "../build"
+warp_ctc_build_path = "../build"
 
 if platform.system() == 'Darwin':
     lib_ext = ".dylib"
 else:
     lib_ext = ".so"
+warp_ctc_libname = 'libwarpctc{}'.format(lib_ext)
 
 if "WARP_CTC_PATH" in os.environ:
-    warp_ctc_path = os.environ["WARP_CTC_PATH"]
-if not os.path.exists(os.path.join(warp_ctc_path, "libwarpctc" + lib_ext)):
-    print(("Could not find libwarpctc.so in {}.\n"
+    warp_ctc_build_path = os.environ["WARP_CTC_PATH"]
+if not os.path.exists(os.path.join(warp_ctc_build_path, warp_ctc_libname)):
+    print(("Could not find {libname} in {build_path}.\n"
            "Build warp-ctc and set WARP_CTC_PATH to the location of"
-           " libwarpctc.so (default is '../build')").format(warp_ctc_path))
+           " {libname} (default is '../build')").format(
+               libname=warp_ctc_libname, build_path=warp_ctc_build_path))
     sys.exit(1)
 
 include_dirs = [os.path.realpath('../include')]
+
+warp_ctc_libpath = "./warpctc_pytorch/lib"
+if not os.path.isdir(warp_ctc_libpath):
+    os.mkdir(warp_ctc_libpath)
+shutil.copyfile(
+    '{}/{}'.format(warp_ctc_build_path, warp_ctc_libname),
+    '{}/{}'.format(warp_ctc_libpath, warp_ctc_libname)
+)
 
 if torch.cuda.is_available() or "CUDA_HOME" in os.environ:
     enable_gpu = True
@@ -44,9 +55,9 @@ ext_modules = [
         language='c++',
         sources=['src/binding.cpp'],
         include_dirs=include_dirs,
-        library_dirs=[os.path.realpath(warp_ctc_path)],
+        library_dirs=[os.path.realpath(warp_ctc_libpath)],
         libraries=['warpctc'],
-        extra_link_args=['-Wl,-rpath,' + os.path.realpath(warp_ctc_path)],
+        extra_link_args=['-Wl,-rpath,{}'.format('$ORIGIN/lib')],
         extra_compile_args=extra_compile_args
     )
 ]
@@ -60,6 +71,7 @@ setup(
     author_email="jared.casper@baidu.com, sean.narenthiran@digitalreasoning.com",
     license="Apache",
     packages=find_packages(),
+    package_data={'': ['lib/{}'.format(warp_ctc_libname)]},
     ext_modules=ext_modules,
     cmdclass={'build_ext': BuildExtension}
 )

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -13,6 +13,7 @@ def _assert_no_grad(tensor):
         "gradients only computed for acts - please " \
         "mark other tensors as not requiring gradients"
 
+
 class _CTC(Function):
     @staticmethod
     def forward(ctx, acts, labels, act_lens, label_lens, size_average=False,
@@ -45,8 +46,9 @@ class _CTC(Function):
                 grads = grads / minibatch_size
                 costs = costs / minibatch_size
         else:
-            costs = costs.unsqueeze(1) # Make the costs size be B x 1, then grad_output is also B x 1
-                                       # Thus the `grad_output' in backward() is broadcastable
+            # Make the costs size be B x 1, then grad_output is also B x 1
+            # Thus the `grad_output' in backward() is broadcastable
+            costs = costs.unsqueeze(1)
 
         ctx.grads = grads
         return costs


### PR DESCRIPTION
# Overview

This PR builds wheel packages for Python3.6 and 3.7 which depends on PyTorch 1.0.0 and CUDA 10.1.
The wheel name is `warpctc_pytorch100_cuda101`, [cupy-cuda](https://pypi.org/project/cupy/) package as reference.
The wheel is built on Travis CI in a Docker container whose base image is `nvidia/cuda:10.1-cudnn7-devel-centos7`.
If this PR is acceptable, I will create PRs for other versions of CUDA such as 10.0, 9.2, 9.1 and 9.0.

# Notes

The wheel is converted to `manylinux1_x86_64` platform tag by renaming manually, not by `auditwheel` command. This is because `.so` files in PyTorch (e.x. `_C.so`) is compiled in newer Linux and running `auditwheel repair warpctc_pytorch100_cuda101-0.1.1-cp36-cp36m-linux_x86_64.whl` fails. According to https://github.com/pytorch/builder/blob/master/manywheel/README.md, PyTorch does not use `auditwheel` command either, and renames its wheel manually to `manylinux1_x86_64`.

I've stopped using miniconda in CI and start using pyenv, because `_warp_ctc.so` compiled with conda enabled depends on newer version of `GLIBCXX` and dynamic linking will fail without miniconda.

Currently wheels are not uploaded to pypi.org. I think they should be uploaded only when the git tag exists.

# Test

I have tested the wheel in CentOS 7 and Ubuntu 18.04. The wheel requires relatively newer versions of Linux distributions (e.x. CentOS7 will be okay but CentOS6 will not).

1. Download [this zip file](https://github.com/espnet/warp-ctc/files/3489944/warpctc_pytorch100_cuda101.zip). It contains `warpctc_pytorch100_cuda101-0.1.1-cp36-cp36m-manylinux1_x86_64.whl` and `warpctc_pytorch100_cuda101-0.1.1-cp37-cp37m-manylinux1_x86_64.whl`. Unzip it and copy wheels to a machine where Python3.6 or 3.7 and CUDA10.1 are installed.

2. Create and activate venv, and run the following command.

```console
$ pip install torch==1.0.0 numpy
$ pip install warpctc_pytorch100_cuda101-0.1.1-cp36-cp36m-manylinux1_x86_64.whl
```

3. Run the code in README.md and confirm that no error occurs.

```python
import torch
from warpctc_pytorch import CTCLoss
ctc_loss = CTCLoss()
# expected shape of seqLength x batchSize x alphabet_size
probs = torch.FloatTensor([[[0.1, 0.6, 0.1, 0.1, 0.1], [0.1, 0.1, 0.6, 0.1, 0.1]]]).transpose(0, 1).contiguous()
labels = torch.IntTensor([1, 2])
label_sizes = torch.IntTensor([2])
probs_sizes = torch.IntTensor([2])
probs.requires_grad_(True)  # tells autograd to compute gradients for probs
cost = ctc_loss(probs, labels, probs_sizes, label_sizes)
cost.backward()
```