### PR TITLE
Build wheels for CUDA 9.2, 10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: python
 services:
   - docker
 env:
+  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
+  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
   - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
   - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
 before_install:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:10.1-cudnn7-devel-centos7
+ARG base_image
+FROM ${base_image}
 
 ENV CUDA_HOME /usr/local/cuda
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,23 @@
+Docker image builder for Travis CI
+===
+
+This directory contains tools to build Docker images used in Travis CI.
+The tools build images by CUDA versions (9.2, 10.1), whose name is `espnet/warpctc_builder:cudaXX` (`XX` is CUDA version without `.`).
+
+## Building Docker images
+
+Run `build.sh`.
+
+```console
+$ ./build.sh
+```
+
+## Uploading images to Dockerhub
+
+Run `docker push`.
+
+```console
+$ docker push espnet/warpctc_builder:cudaXX
+```
+
+Note that your Dockerhub account have write access to [espnet/warpctc_builder](https://hub.docker.com/r/espnet/warpctc_builder) repository.

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+image_repository=espnet/warpctc_builder
+cuda_versions=(9.2 10.1)
+for cuda_version in ${cuda_versions[@]}; do
+  base_image="nvidia/cuda:$cuda_version-cudnn7-devel-centos7"
+  image_tag=cuda${cuda_version/./}
+  image_name=$image_repository:$image_tag
+  echo "Building $image_name"
+  docker build --build-arg base_image=$base_image -t $image_name .
+  echo Done.
+done


### PR DESCRIPTION
This PR enables to build wheels which depends on CUDA9.2 and 10.1.
Currently, CI builds on latest minor version of each major version of CUDA (e.x. 10.1 but not 10.0).