### PR TITLE
Exclude maintenance version of PyTorch from wheel name

### DIFF
--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -45,7 +45,8 @@ def get_cuda_version():
 
 
 def get_torch_version():
-    return torch.__version__.replace('.', '')
+    major_ver, minor_ver, _ = torch.__version__.split('.')
+    return major_ver + minor_ver
 
 
 if torch.cuda.is_available() or "CUDA_HOME" in os.environ:


### PR DESCRIPTION
fixes #6 