### PR TITLE
Upload wheels to PyPI (only when a git tag exists)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,14 @@ language: python
 services:
   - docker
 env:
+  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda90
+  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda90
+  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda91
+  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda91
   - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
   - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
+  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
+  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
   - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
   - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
   - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - docker exec -e PYTHON_VERSION=$PYTHON_VERSION warpctc_builder_container /bin/bash -cl \
     'pyenv global $PYTHON_VERSION'
   - docker exec warpctc_builder_container /bin/bash -cl \
-    'pip install -U pip setuptools && pip install pytest pytest-pep8 wheel'
+    'pip install -U pip setuptools && pip install pytest pytest-pep8 wheel twine'
   - docker exec -e TORCH_VERSION=$TORCH_VERSION warpctc_builder_container /bin/bash -cl \
     'pip install torch==$TORCH_VERSION torchvision'
 
@@ -33,6 +33,10 @@ script:
     'cd pytorch_binding && py.test --pep8 -m pep8 --ignore=warpctc_pytorch/_warp_ctc'
   - docker exec warpctc_builder_container /bin/bash -cl \
     'cd pytorch_binding && ls -1 dist/*.whl | awk "{print \"mv \"\$1\" \"\$1}" | sed "s/-linux_/-manylinux1_/2" | bash && ls dist/'
+  - if [ "$TRAVIS_TAG" != "" ]; then
+    docker exec warpctc_builder_container /bin/bash -cl \
+    'cd pytorch_binding && twine upload --config-file .pypirc dist/*.whl';
+    fi
 
 after_script:
   - docker stop warpctc_builder_container

--- a/pytorch_binding/.pypirc
+++ b/pytorch_binding/.pypirc
@@ -1,0 +1,8 @@
+[distutils]
+index-servers =
+  pypi
+
+[pypi]
+repository: https://upload.pypi.org/legacy/
+username: __token__
+password: pypi-AgEIcHlwaS5vcmcCJGI1YmJiYTM4LTI2YmYtNDRhNC05YWQyLWVmZDJkNDA1YmEyYgACJXsicGVybWlzc2lvbnMiOiAidXNlciIsICJ2ZXJzaW9uIjogMX0AAAYge0xCXFm0MOF-K_T5uo7Ds2vvaMNwACC3bm6z2azpAYE

--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -81,10 +81,22 @@ ext_modules = [
 setup(
     name=package_name,
     version="0.1.1",
-    description="PyTorch wrapper for warp-ctc",
-    url="https://github.com/baidu-research/warp-ctc",
-    author="Jared Casper, Sean Naren",
-    author_email="jared.casper@baidu.com, sean.narenthiran@digitalreasoning.com",
+    description="Pytorch Bindings for warp-ctc maintained by ESPnet",
+    url="https://github.com/espnet/warp-ctc",
+    author=[
+        "Jared Casper",
+        "Sean Naren",
+        "Shinji Watanabe",
+        "Jiro Nishitoba",
+        "Yusuke Nishioka"
+    ],
+    author_email=[
+        "jared.casper@baidu.com",
+        "sean.narenthiran@digitalreasoning.com",
+        "sw005320@gmail.com",
+        "j.nshtb+github@gmail.com",
+        "yusuke.nishioka.0713@gmail.com"
+    ],
     license="Apache",
     packages=find_packages(),
     package_data={'': ['lib/{}'.format(warp_ctc_libname)]},


### PR DESCRIPTION
fixes #7 

This pull request will build wheels for CUDA 9.0, 9.1 and 10.0 and upload wheels to pypi.org (finally!), only when a git tag exists.

I've tested with my account of test.pypi.org and confirmed that the wheels are uploaded (I will delete these later).

- https://test.pypi.org/project/warpctc-pytorch100-cuda101/
- https://test.pypi.org/project/warpctc-pytorch100-cuda92/
- https://test.pypi.org/project/warpctc-pytorch100-cpu/

After this PR is merged, I will
- create a new branch named `pytorch-1.0` from `pytorch-1.0.0` branch (see #8 for branch reorganization)
- push `v0.1.1-pytorch1.0` tag to the latest commit of the new branch
- and confirm whether the wheels are safely uploaded to pypi.org.
