### PR TITLE
Update version to 0.1.2 of warpctc-pytorch10-XXX wheels

### DIFF
--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -81,7 +81,7 @@ ext_modules = [
 
 setup(
     name=package_name,
-    version="0.1.1",
+    version="0.1.2",
     description="Pytorch Bindings for warp-ctc maintained by ESPnet",
     url="https://github.com/espnet/warp-ctc",
     author=','.join([

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -5,7 +5,7 @@ from torch.nn import Module
 
 from ._warp_ctc import *
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 def _assert_no_grad(tensor):


### PR DESCRIPTION
I've added `v0.1.1-pytorch1.0` tag to 4a7d748 and
- [`warpctc-pytorch10-cuda100`](https://pypi.org/project/warpctc-pytorch10-cuda100/)
- [`warpctc-pytorch10-cuda92`](https://pypi.org/project/warpctc-pytorch10-cuda92/)
- [`warpctc-pytorch10-cuda91`](https://pypi.org/project/warpctc-pytorch10-cuda91/)
- [`warpctc-pytorch10-cuda90`](https://pypi.org/project/warpctc-pytorch10-cuda90/)

uploading 4 wheels above to pypi.org has succeeded, but

- `warpctc-pytorch10-cuda101`
- `warpctc-pytorch10-cpu`

uploading these 2 wheels failed (see https://travis-ci.org/espnet/warp-ctc/builds/584611199),
because [PyPI doesn't allow uploading  the same file](https://stackoverflow.com/questions/52016336/how-to-upload-new-versions-of-project-to-pypi-with-twine) and I had already uploaded those two files when testing with my account.

To avoid this "This filename has already been used" error, I have to change package name or version, and I chose to change version and update it to 0.1.2. After this pull request is merged, I will add `v0.1.2-pytorch1.0` tag to let CI upload wheels.
Note that this version update works only for `warpctc-pytorch10-XXX` wheels. When I adapt the code to PyTorch 1.1 in the near future, `warpctc-pytorch11-XXX` wheels will be version 0.1.1. That version mismatch sounds a little bit weird, but not a big problem, I think.