### PR TITLE
Build a wheel for CUDA 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: python
 services:
   - docker
 env:
+  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda80
+  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda80
   - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda90
   - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda90
   - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda91

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,7 +4,11 @@ Docker image builder for Travis CI
 This directory contains tools to build following Docker images used in Travis CI,
 
 - `espnet/warpctc_builder:cuda101` for CUDA 10.1
+- `espnet/warpctc_builder:cuda100` for CUDA 10.0
 - `espnet/warpctc_builder:cuda92` for CUDA 9.2
+- `espnet/warpctc_builder:cuda91` for CUDA 9.1
+- `espnet/warpctc_builder:cuda90` for CUDA 9.0
+- `espnet/warpctc_builder:cuda80` for CUDA 8.0
 - `espnet/warpctc_builder:cpu` for no CUDA environment
 
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 image_repository=espnet/warpctc_builder
-cuda_versions=(9.2 10.1)
+cuda_versions=(8.0 9.0 9.1 9.2 10.0 10.1)
 for cuda_version in ${cuda_versions[@]}; do
   base_image="nvidia/cuda:$cuda_version-cudnn7-devel-centos7"
   image_tag=cuda${cuda_version/./}


### PR DESCRIPTION
I decided to build wheel for CUDA 8.0, because this makes installation in tools/Makefile of ESPnet simpler. 

```
if $CUPY_VERSION is not empty  # GPU enabled
  if $CUDA_VERSION != 8.0
    pip install warpctc-pytorch10-cudaXX
  else
    build from source 
  fi
else  # CPU only
  pip install warpctc-pytorch10-cpu
fi
```

This becomes simpler like this,

```
if $CUPY_VERSION is not empty  # GPU enabled
  pip install warpctc-pytorch10-cudaXX
else  # CPU only
  pip install warpctc-pytorch10-cpu
fi
```

After this PR is merged, I will cherry-pick this commit to `pytorch-1.0` branch.