### PR TITLE
Update version of warpctc-pytorch10-XXX to v0.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: python
 services:
   - docker
 env:
+  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda80
+  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda80
   - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda90
   - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda90
   - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.0.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda91

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,7 +4,11 @@ Docker image builder for Travis CI
 This directory contains tools to build following Docker images used in Travis CI,
 
 - `espnet/warpctc_builder:cuda101` for CUDA 10.1
+- `espnet/warpctc_builder:cuda100` for CUDA 10.0
 - `espnet/warpctc_builder:cuda92` for CUDA 9.2
+- `espnet/warpctc_builder:cuda91` for CUDA 9.1
+- `espnet/warpctc_builder:cuda90` for CUDA 9.0
+- `espnet/warpctc_builder:cuda80` for CUDA 8.0
 - `espnet/warpctc_builder:cpu` for no CUDA environment
 
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 image_repository=espnet/warpctc_builder
-cuda_versions=(9.2 10.1)
+cuda_versions=(8.0 9.0 9.1 9.2 10.0 10.1)
 for cuda_version in ${cuda_versions[@]}; do
   base_image="nvidia/cuda:$cuda_version-cudnn7-devel-centos7"
   image_tag=cuda${cuda_version/./}

--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -81,7 +81,7 @@ ext_modules = [
 
 setup(
     name=package_name,
-    version="0.1.2",
+    version="0.1.3",
     description="Pytorch Bindings for warp-ctc maintained by ESPnet",
     url="https://github.com/espnet/warp-ctc",
     author=','.join([

--- a/pytorch_binding/warpctc_pytorch/__init__.py
+++ b/pytorch_binding/warpctc_pytorch/__init__.py
@@ -5,7 +5,7 @@ from torch.nn import Module
 
 from ._warp_ctc import *
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 
 def _assert_no_grad(tensor):


### PR DESCRIPTION
This pull request enables building `warpctc-pytorch10-cuda80` wheel and the version is updated to 0.1.3.
151aeaa is cherry-picked from 8c00a8a.
After this pull request is merged, I will add `v0.1.3-pytorch1.0` tag.