### PR TITLE
Encrypt PyPI token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,23 @@ language: python
 services:
   - docker
 env:
-  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda80
-  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda80
-  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda90
-  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda90
-  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda91
-  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda91
-  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
-  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
-  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
-  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
-  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
-  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
-  - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu
-  - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu
+  matrix:
+    - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda80
+    - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda80
+    - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda90
+    - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda90
+    - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda91
+    - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda91
+    - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
+    - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
+    - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
+    - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
+    - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
+    - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
+    - PYTHON_VERSION=3.6.9 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu
+    - PYTHON_VERSION=3.7.4 TORCH_VERSION=1.1.0 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu
+  global:
+    - secure: "P5iuxWY7zhu2lSXjRAikAWNDIwATrQl40TqO6z2dA2E0jBDPoewpLra6lqBDu715Tc+yFDaf/fpfKlM7sn02HGKRnapQB5N9YwI03M5AYTEQS9NvKK603LmRlpQbJZwKCzs0blgcawHmoeFjnFoz0zToWyR+kIYJvUr17T8LWNimcHTv8tVks2bnEOJYEqZKHajz1ORSQ67oV18xx755OP5w71lA0YF/Dh7bGpSamOUkUAOuCva8LKdJwM2w+r4tfhWXZDWpcgFh2WE2qPnmSkPq6jjNZJxAs//2Bn3zi3VhXjs+njuPi+cjvEfbwriVo9iwvK2OlXjygCbY3Sw8a2IeSHccEiaUgG/Ub1g3qsVn2pG6QT6xOQSAbsplPMUJBrrHZfEAxZ8uAAQ9ZkOst2TG+5lEf+0eqRDG6LXiuj2TiRGeXeUIup0MlTbPWvR9tN/aRVHuiGmGKtcklEpICM6tDK0RKlLJ5YYhx4CBXG3EpD/91hFtvhg/7y7RxZmJ+yTXD8b5CtnQdgbt86jZENsRlh/HfIAwiwosElL/ihcMLpTo/v+9ixpSCeiVxjHao3LAO2NXYyRNg/H22kfy8XDzH5dv1Dz7wQu9Z6r29DOAUDe0pH96ql3B/dfFZF282M4zpfuO4cv+0Fw178i721RKzFI+9j6GahgmUk0ZKvU="
 before_install:
   - docker pull $DOCKER_IMAGE_NAME
   - docker run --rm -d --name warpctc_builder_container -v ${PWD}:${PWD} -w ${PWD} $DOCKER_IMAGE_NAME sleep inf
@@ -42,8 +45,8 @@ script:
   - docker exec warpctc_builder_container /bin/bash -cl \
     'cd pytorch_binding && ls -1 dist/*.whl | awk "{print \"mv \"\$1\" \"\$1}" | sed "s/-linux_/-manylinux1_/2" | bash && ls dist/'
   - if [ "$TRAVIS_TAG" != "" ]; then
-    docker exec warpctc_builder_container /bin/bash -cl \
-    'cd pytorch_binding && twine upload --config-file .pypirc dist/*.whl';
+    docker exec -e PYPI_TOKEN=$PYPI_TOKEN warpctc_builder_container /bin/bash -cl \
+    'cd pytorch_binding && twine upload --config-file .pypirc -p $PYPI_TOKEN dist/*.whl';
     fi
 
 after_script:

--- a/pytorch_binding/.pypirc
+++ b/pytorch_binding/.pypirc
@@ -5,4 +5,3 @@ index-servers =
 [pypi]
 repository: https://upload.pypi.org/legacy/
 username: __token__
-password: pypi-AgEIcHlwaS5vcmcCJGI1YmJiYTM4LTI2YmYtNDRhNC05YWQyLWVmZDJkNDA1YmEyYgACJXsicGVybWlzc2lvbnMiOiAidXNlciIsICJ2ZXJzaW9uIjogMX0AAAYge0xCXFm0MOF-K_T5uo7Ds2vvaMNwACC3bm6z2azpAYE


### PR DESCRIPTION
I've added new API token to upload wheels to PyPI and encrypt the token following https://docs.travis-ci.com/user/encryption-keys .
Although we cannot confirm that uploading wheels succeeds with this PR because encrypted token does not work by pull requests from forked repositories, I've tested that uploading succeeds on [debug_pypi_token_encryption](https://github.com/espnet/warp-ctc/tree/debug_pypi_token_encryption) branch of espnet/warp-ctc repository.