### PR TITLE
Build one wheel by using local version identifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ script:
   - docker exec warpctc_builder_container /bin/bash -cl \
     'cd pytorch_binding && py.test --pep8 -m pep8 --ignore=warpctc_pytorch/_warp_ctc'
   - docker exec warpctc_builder_container /bin/bash -cl \
-    'cd pytorch_binding && ls -1 dist/*.whl | awk "{print \"mv \"\$1\" \"\$1}" | sed "s/-linux_/-manylinux1_/2" | bash && ls dist/'
+    'cd pytorch_binding && python3 wheel/rename_wheels.py && ls dist/'
   - if [ "$TRAVIS_TAG" != "" ]; then
     docker exec -e PYPI_TOKEN=$PYPI_TOKEN warpctc_builder_container /bin/bash -cl \
     'cd pytorch_binding && twine upload --config-file .pypirc -p $PYPI_TOKEN dist/*.whl';

--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -3,7 +3,6 @@ import platform
 import shutil
 import sys
 from setuptools import setup, find_packages
-from subprocess import Popen, PIPE
 
 from torch.utils.cpp_extension import BuildExtension, CppExtension
 import torch
@@ -37,18 +36,6 @@ shutil.copyfile(
 )
 
 
-def get_cuda_version():
-    proc = Popen(['nvcc', '--version'], stdout=PIPE, stderr=PIPE)
-    out, err = proc.communicate()
-    out.decode('utf-8').split('\n')[-2].split(', ')[-2].split(' ')
-    return out.decode('utf-8').split()[-2][:-1].replace('.', '')
-
-
-def get_torch_version():
-    major_ver, minor_ver = torch.__version__.split('.')[:2]
-    return major_ver + minor_ver
-
-
 if torch.cuda.is_available() or "CUDA_HOME" in os.environ:
     enable_gpu = True
 else:
@@ -60,11 +47,8 @@ if enable_gpu:
 
     build_extension = CUDAExtension
     extra_compile_args += ['-DWARPCTC_ENABLE_GPU']
-    package_name = 'warpctc_pytorch{}_cuda{}'.format(
-        get_torch_version(), get_cuda_version())
 else:
     build_extension = CppExtension
-    package_name = 'warpctc_pytorch{}_cpu'.format(get_torch_version())
 
 ext_modules = [
     build_extension(
@@ -80,7 +64,7 @@ ext_modules = [
 ]
 
 setup(
-    name=package_name,
+    name="warpctc_pytorch",
     version="0.1.2",
     description="Pytorch Bindings for warp-ctc maintained by ESPnet",
     url="https://github.com/espnet/warp-ctc",

--- a/pytorch_binding/wheel/rename_wheels.py
+++ b/pytorch_binding/wheel/rename_wheels.py
@@ -1,0 +1,36 @@
+import glob
+import os
+import shutil
+from subprocess import Popen, PIPE
+
+import torch
+
+
+def get_cuda_version():
+    proc = Popen(['nvcc', '--version'], stdout=PIPE, stderr=PIPE)
+    out, err = proc.communicate()
+    out.decode('utf-8').split('\n')[-2].split(', ')[-2].split(' ')
+    return out.decode('utf-8').split()[-2][:-1].replace('.', '')
+
+
+def get_torch_version():
+    major_ver, minor_ver = torch.__version__.split('.')[:2]
+    return major_ver + minor_ver
+
+
+local_version_identifier = '+torch{}'.format(get_torch_version())
+if torch.cuda.is_available() or "CUDA_HOME" in os.environ:
+    enable_gpu = True
+    local_version_identifier += ".cuda{}".format(get_cuda_version())
+else:
+    local_version_identifier = ".cpu"
+
+
+for whl_path in glob.glob(os.path.join(os.getcwd(), 'dist', '*.whl')):
+    whl_name = os.path.basename(whl_path)
+    dist, version, python_tag, abi_tag, platform_tag = whl_name.split('-')
+    version += local_version_identifier
+    platform_tag = platform_tag.replace('linux', 'manylinux1')
+    new_whl_name = '-'.join([dist, version, python_tag, abi_tag, platform_tag])
+    new_whl_path = os.path.join(os.path.dirname(whl_path), new_whl_name)
+    shutil.move(whl_path, new_whl_path)


### PR DESCRIPTION
Now v0.1.2 is released, but there are too many `warpctc-pytorchXX-cudaYY` packages... https://pypi.org/search/?q=warpctc .
If we continue this pace, CUDA version (8.0, 9,0, 9.1, 9.2, 10.0, 10.1, 10.2, ...) x PyTorch version (1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, ...) = at least 49 packages! I think this is not realistic.

This pull request builds one wheel `warpctc-pytorch` and represents PyTorch version and CUDA version in [the local version identifier](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers), e.g. `warpctc_pytorch-0.1.2+torch12.cuda101-cp37-cp37m-manylinux1_x86_64.whl` .
I've tested uploading to test.pypi.org and it seems PyPI server accepts wheels with local version identifiers, see https://test.pypi.org/project/warpctc-pytorch/88.77.66/#files . I hope the same goes for pypi.org.
Users can download wheels by specifying the local version identifier, e.g. `pip install warpctc-pytorch==0.1.2+torch12.cuda101` .

After this pull request is merged, I'm going to delete `warpctc-pytorch13*` and `warpctc-pytorch12*` packages from pypi.org and release new version to upload `warpctc-pytorch` packages. I'll leave `warpctc-pytorch11*` and `warpctc-pytorch10*` as it is for backward compatibillity.