### PR TITLE
Fix bug of rename_wheels.py

### DIFF
--- a/pytorch_binding/wheel/rename_wheels.py
+++ b/pytorch_binding/wheel/rename_wheels.py
@@ -23,7 +23,7 @@ if torch.cuda.is_available() or "CUDA_HOME" in os.environ:
     enable_gpu = True
     local_version_identifier += ".cuda{}".format(get_cuda_version())
 else:
-    local_version_identifier = ".cpu"
+    local_version_identifier += ".cpu"
 
 
 for whl_path in glob.glob(os.path.join(os.getcwd(), 'dist', '*.whl')):


### PR DESCRIPTION
Fixed a bug that wheels for CPU environment are uploaded as `warpctc_pytorch-X.Y.Z.cpu`, not `warpctc_pytorch-X.Y.Z+torchXX.cpu` .