### PR TITLE
Build wheels with PyTorch up to v1.6 and Python up to v3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,30 +5,18 @@ services:
   - docker
 env:
   matrix:
-    - TORCH_VERSION=1.1.0 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
-    - TORCH_VERSION=1.1.0 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
-    - TORCH_VERSION=1.1.0 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
-    - TORCH_VERSION=1.1.0 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
-    - TORCH_VERSION=1.1.0 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
-    - TORCH_VERSION=1.1.0 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
-    - TORCH_VERSION=1.1.0 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu
-    - TORCH_VERSION=1.1.0 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu
-    - TORCH_VERSION=1.2.0 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
-    - TORCH_VERSION=1.2.0 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
-    - TORCH_VERSION=1.2.0 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
-    - TORCH_VERSION=1.2.0 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
-    - TORCH_VERSION=1.2.0 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
-    - TORCH_VERSION=1.2.0 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
-    - TORCH_VERSION=1.2.0 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu
-    - TORCH_VERSION=1.2.0 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu
-    - TORCH_VERSION=1.3.1 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
-    - TORCH_VERSION=1.3.1 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92
-    - TORCH_VERSION=1.3.1 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
-    - TORCH_VERSION=1.3.1 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100
-    - TORCH_VERSION=1.3.1 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
-    - TORCH_VERSION=1.3.1 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101
-    - TORCH_VERSION=1.3.1 PYTHON_VERSION=3.6.12 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu
-    - TORCH_VERSION=1.3.1 PYTHON_VERSION=3.7.9 DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92 PYTHON_VERSION=3.6.12 TORCH_VERSIONS=1.1.0:1.2.0:1.3.1:1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92 PYTHON_VERSION=3.7.9 TORCH_VERSIONS=1.1.0:1.2.0:1.3.1:1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda92 PYTHON_VERSION=3.8.5 TORCH_VERSIONS=1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100 PYTHON_VERSION=3.6.12 TORCH_VERSIONS=1.1.0:1.2.0:1.3.1:1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100 PYTHON_VERSION=3.7.9 TORCH_VERSIONS=1.1.0:1.2.0:1.3.1:1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda100 PYTHON_VERSION=3.8.5 TORCH_VERSIONS=1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101 PYTHON_VERSION=3.6.12 TORCH_VERSIONS=1.1.0:1.2.0:1.3.1:1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101 PYTHON_VERSION=3.7.9 TORCH_VERSIONS=1.1.0:1.2.0:1.3.1:1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cuda101 PYTHON_VERSION=3.8.5 TORCH_VERSIONS=1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu PYTHON_VERSION=3.6.12 TORCH_VERSIONS=1.1.0:1.2.0:1.3.1:1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu PYTHON_VERSION=3.7.9 TORCH_VERSIONS=1.1.0:1.2.0:1.3.1:1.4.0:1.5.1:1.6.0
+    - DOCKER_IMAGE_NAME=espnet/warpctc_builder:cpu PYTHON_VERSION=3.8.5 TORCH_VERSIONS=1.4.0:1.5.1:1.6.0
   global:
     - secure: "P5iuxWY7zhu2lSXjRAikAWNDIwATrQl40TqO6z2dA2E0jBDPoewpLra6lqBDu715Tc+yFDaf/fpfKlM7sn02HGKRnapQB5N9YwI03M5AYTEQS9NvKK603LmRlpQbJZwKCzs0blgcawHmoeFjnFoz0zToWyR+kIYJvUr17T8LWNimcHTv8tVks2bnEOJYEqZKHajz1ORSQ67oV18xx755OP5w71lA0YF/Dh7bGpSamOUkUAOuCva8LKdJwM2w+r4tfhWXZDWpcgFh2WE2qPnmSkPq6jjNZJxAs//2Bn3zi3VhXjs+njuPi+cjvEfbwriVo9iwvK2OlXjygCbY3Sw8a2IeSHccEiaUgG/Ub1g3qsVn2pG6QT6xOQSAbsplPMUJBrrHZfEAxZ8uAAQ9ZkOst2TG+5lEf+0eqRDG6LXiuj2TiRGeXeUIup0MlTbPWvR9tN/aRVHuiGmGKtcklEpICM6tDK0RKlLJ5YYhx4CBXG3EpD/91hFtvhg/7y7RxZmJ+yTXD8b5CtnQdgbt86jZENsRlh/HfIAwiwosElL/ihcMLpTo/v+9ixpSCeiVxjHao3LAO2NXYyRNg/H22kfy8XDzH5dv1Dz7wQu9Z6r29DOAUDe0pH96ql3B/dfFZF282M4zpfuO4cv+0Fw178i721RKzFI+9j6GahgmUk0ZKvU="
 before_install:
@@ -38,26 +26,15 @@ install:
   - docker exec -e PYTHON_VERSION=$PYTHON_VERSION warpctc_builder_container /bin/bash -cl \
     'pyenv global $PYTHON_VERSION'
   - docker exec warpctc_builder_container /bin/bash -cl \
-    "pip install -U pip setuptools && pip install pytest pytest-flakes wheel twine"
-  - docker exec -e TORCH_VERSION=$TORCH_VERSION warpctc_builder_container /bin/bash -cl \
-    'pip install torch==$TORCH_VERSION torchvision'
-
-  - docker exec warpctc_builder_container /bin/bash -cl \
-    'mkdir build && cd build && cmake .. && make'
-  - docker exec warpctc_builder_container /bin/bash -cl \
-    'cd pytorch_binding && python setup.py bdist_wheel && pip install dist/*.whl'
-
+    "pip install -U pip setuptools && pip install numpy pytest pytest-flakes wheel twine"
 script:
   - docker exec warpctc_builder_container /bin/bash -cl \
-    'cd pytorch_binding && py.test tests'
-  - docker exec warpctc_builder_container /bin/bash -cl \
-    'cd pytorch_binding && py.test --flakes --ignore=warpctc_pytorch/_warp_ctc'
-  - docker exec warpctc_builder_container /bin/bash -cl \
-    'cd pytorch_binding && python3 wheel/rename_wheels.py && ls dist/'
+    'mkdir build && cd build && cmake .. && make'
+  - docker exec -e TORCH_VERSIONS=$TORCH_VERSIONS warpctc_builder_container /bin/bash -cl \
+    'cd pytorch_binding && ./wheel/build_wheels.sh && ls dist'
   - if [ "$TRAVIS_TAG" != "" ]; then
     docker exec -e PYPI_TOKEN=$PYPI_TOKEN warpctc_builder_container /bin/bash -cl \
     'cd pytorch_binding && twine upload --config-file .pypirc -p $PYPI_TOKEN dist/*.whl';
     fi
-
 after_script:
   - docker stop warpctc_builder_container

--- a/pytorch_binding/wheel/build_wheels.sh
+++ b/pytorch_binding/wheel/build_wheels.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -eu
+
+function install_torch_of_specified_version() {
+  version=$1
+  pip install torch==$1
+}
+
+function build_wheel() {
+  python setup.py bdist_wheel
+  python wheel/rename_wheels.py
+}
+
+function install_wheel() {
+  torch_version=$1
+
+  torch_vers=(${torch_version//./ })
+  torch_major_ver=${torch_vers[0]}
+  torch_minor_ver=${torch_vers[1]}
+  pip install dist/warpctc_pytorch-*+torch${torch_major_ver}${torch_minor_ver}*.whl
+}
+
+function run_tests() {
+  pytest tests
+  pytest --flakes
+}
+
+function post_process() {
+  python setup.py clean
+  pip uninstall -y warpctc-pytorch torch
+  rm -rf build warpctc_pytorch.egg-info
+}
+
+torch_versions=(${TORCH_VERSIONS//:/ })
+for torch_version in ${torch_versions[@]}; do
+  install_torch_of_specified_version $torch_version
+  build_wheel
+  install_wheel $torch_version
+  run_tests
+  post_process
+done

--- a/pytorch_binding/wheel/rename_wheels.py
+++ b/pytorch_binding/wheel/rename_wheels.py
@@ -29,6 +29,8 @@ else:
 for whl_path in glob.glob(os.path.join(os.getcwd(), 'dist', '*.whl')):
     whl_name = os.path.basename(whl_path)
     dist, version, python_tag, abi_tag, platform_tag = whl_name.split('-')
+    if '+' in version:
+        continue
     version += local_version_identifier
     platform_tag = platform_tag.replace('linux', 'manylinux1')
     new_whl_name = '-'.join([dist, version, python_tag, abi_tag, platform_tag])


### PR DESCRIPTION
This pull request enables building wheels with the following combinations:

- Python3.8
  - PyTorch 1.4-1.6
- Python3.7 and 3.6
  - PyTorch 1.1-1.6

This PR also reduces the number of jobs on TravisCI to minimize `docker pull` time. One job builds wheels with several versions of PyTorch (so far, one job builds one wheel).